### PR TITLE
feat: Expandable text for projects page

### DIFF
--- a/src/components/ExpandableText.jsx
+++ b/src/components/ExpandableText.jsx
@@ -1,0 +1,32 @@
+import React, {useState} from "react";
+import {Box, Typography, Button} from "@mui/material";
+
+// props needs props.lines
+function ExpandableText(props) {
+    const [isExpanded, setIsExpanded] = useState(false);  // whether the text is currently expanded
+
+    return (
+        <Box>
+            <Typography variant="body2" color="textSecondary" sx={
+                // truncate text with CSS when text is not expanded
+                // otherwise use default styles
+                (!isExpanded) ?
+                {
+                    overflow: "hidden", 
+                    display: "-webkit-box", 
+                    WebkitLineClamp: props.lines, 
+                    WebkitBoxOrient: "vertical", 
+                    textOverflow: "ellipsis",
+                } : {}}>
+                    {props.children}
+                </Typography>
+            <Button variant="link" disableRipple onClick={() => {
+                setIsExpanded(!isExpanded);
+            }}>
+                {(isExpanded)? "Read less" : "Read more"}
+            </Button>
+        </Box>
+    );
+}
+
+export default ExpandableText;

--- a/src/screens/ProjectsPage.jsx
+++ b/src/screens/ProjectsPage.jsx
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from 'react';
 import {Card, CardContent, Typography, Grid, CircularProgress, CardMedia, Pagination, Box, Alert} from '@mui/material';
 import {getProjectData} from '../services/projectDataService';
 import {Typewriter} from "react-simple-typewriter";
+import ExpandableText from '../components/ExpandableText';
 
 // ProjectsPage Component: Displays a list of projects with pagination
 function ProjectsPage() {
@@ -70,17 +71,7 @@ function ProjectsPage() {
                             />
                             <CardContent>
                                 <Typography variant="h5">{project.title}</Typography>
-                                <Typography variant="body2" color="textSecondary">
-                                    {project.description}
-                                </Typography>
-                                {/*<Typography component="a" href={project.link} target="_blank" rel="noopener noreferrer"*/}
-                                {/*            sx={{*/}
-                                {/*                textDecoration: 'none',*/}
-                                {/*                color: 'primary.main',*/}
-                                {/*                '&:hover': {textDecoration: 'underline'}*/}
-                                {/*            }}>*/}
-                                {/*    Learn More*/}
-                                {/*</Typography>*/}
+                                <ExpandableText lines="3">{project.description}</ExpandableText>
                             </CardContent>
                         </Card>
                     </Grid>

--- a/src/themes/primaryTheme.js
+++ b/src/themes/primaryTheme.js
@@ -128,6 +128,13 @@ let theme = createTheme({
                 containedSecondary: {
                     background: 'linear-gradient(to right, #ff9a76, #ffcd56)',
                 },
+                link: { // a button styled to look like a link
+                    '&:hover': {
+                        backgroundColor: "transparent",
+                    }, 
+                    padding: 0, 
+                    color: "#2ebac6",
+                }
             },
         },
     },


### PR DESCRIPTION
- Create ExpandableText component with "lines" prop to determine how many lines to display before truncating
- Use ExpandableText in projects page
- Add link button theme to display a button styled as text (better for accessibility than using MUI Link)